### PR TITLE
Update bplist.c

### DIFF
--- a/src/NppBplistPlugin/dependencies/libimobiledevice/libplist/src/bplist.c
+++ b/src/NppBplistPlugin/dependencies/libimobiledevice/libplist/src/bplist.c
@@ -310,7 +310,7 @@ static plist_t parse_date_node(char *bnode, uint8_t size)
     plist_data_t data = plist_get_data(node);
 
     double time_real = data->realval;
-    data->timeval.tv_sec = (long) time_real;
+    data->timeval.tv_sec = (long) time_real + 978307200;
     data->timeval.tv_usec = (time_real - (long) time_real) * 1000000;
     data->type = PLIST_DATE;
     data->length = sizeof(timeval_t);


### PR DESCRIPTION
Modified "parse_date_node" function to add 978307200 seconds to "time_real" to convert Apple Cocoa Core Data timestamps properly. Otherwise, they appeared 31 years in the past.